### PR TITLE
fix: Garbage insertion during POST to /files

### DIFF
--- a/app/main.go
+++ b/app/main.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"net"
 	"os"
+	"strconv"
 	"strings"
 	"unicode/utf8"
 )
@@ -42,7 +44,7 @@ func main() {
 func Handlereq(conn net.Conn) {
 	tempDirectory := "temp"
 	buff := make([]byte, 1024)
-	conn.Read(buff)
+	n, _ := conn.Read(buff)
 
 	parts := strings.Split(string(buff), CRLF)
 	len_of_parts := len(parts)
@@ -77,61 +79,107 @@ func Handlereq(conn net.Conn) {
 	}
 
 	if lineparts[1] == "/" {
-		conn.Write([]byte("http/1.1 200 OK\r\n\r\n"))
-		fmt.Println(("These is /"))
+		body := "You have hit /" + "\n"
+		response := "HTTP/1.1 200 OK\r\n" +
+			"Content-Type: text/plain\r\n" +
+			"Content-Length: " + strconv.Itoa(len(body)) + "\r\n" +
+			"\r\n" +
+			body
+
+		conn.Write([]byte(response))
+		fmt.Println("These is /")
 
 	} else if strings.HasPrefix(lineparts[1], "/echo") {
 		newParts := strings.Split(lineparts[1], "/")
 		if len(newParts) > 3 {
-			conn.Write([]byte("http/1.1 404 Not Found\r\n\r\n"))
+			send404(conn)
+			return
 		}
 		text := newParts[2]
 		textlength := len(newParts[2])
 
-		conn.Write([]byte(fmt.Sprintf("HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: %d\r\n\r\n%s", textlength, text)))
+		conn.Write([]byte(
+			fmt.Sprintf(
+				"HTTP/1.1 200 OK\r\n"+
+					"Content-Type: text/plain\r\n"+
+					"Content-Length: %d\r\n\r\n%s",
+				textlength,
+				text,
+			),
+		))
 
 	} else if strings.HasPrefix(lineparts[1], "/user-agent") {
 		content := header["User-Agent"]
 		contentlen := len(content)
-		conn.Write([]byte(fmt.Sprintf("HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: %d\r\n\r\n%s", contentlen, content)))
+		conn.Write([]byte(
+			fmt.Sprintf(
+				"HTTP/1.1 200 OK\r\n"+
+					"Content-Type: text/plain\r\n"+
+					"Content-Length: %d\r\n\r\n%s",
+				contentlen,
+				content,
+			),
+		))
 
-	} else if request.Method == "GET" && strings.HasPrefix (request.Url, "/files") {
+	} else if request.Method == "GET" && strings.HasPrefix(request.Url, "/files") {
 		fileparts := strings.Split(request.Url, "/")
 
 		filename := fileparts[2]
 		filepath := fmt.Sprintf("%s/%s", tempDirectory, filename)
 
 		if len(fileparts) > 3 {
-			conn.Write([]byte("http/1.1 404 Not Found\r\n\r\n"))
+			send404(conn)
 			return
 		}
 
 		if _, err := os.Stat(filepath); errors.Is(err, os.ErrNotExist) {
-			conn.Write([]byte("http/1.1 404 Not Found\r\n\r\n"))
+			send404(conn)
 			return
 		}
 		content, _ := os.ReadFile(filepath)
 		contentLength := utf8.RuneCountInString(string(content))
-		conn.Write([]byte(fmt.Sprintf("HTTP/1.1 200 OK\r\nContent-Type: application/octet-stream\r\nContent-Length: %d\r\n\r\n%s", contentLength, content)))
+		conn.Write([]byte(
+			fmt.Sprintf(
+				"HTTP/1.1 200 OK\r\n"+
+					"Content-Type: application/octet-stream\r\n"+
+					"Content-Length: %d\r\n\r\n%s", contentLength, content)))
+
 	} else if request.Method == "POST" && strings.HasPrefix(request.Url, "/files/") {
 		fileparts := strings.Split(request.Url, "/")
 		filname := fileparts[2]
 		filepath := fmt.Sprintf("%s/%s", tempDirectory, filname)
+
 		if len(fileparts) > 3 {
-			conn.Write([]byte("http/1.1 404 Not Found\r\n\r\n"))
+			send404(conn)
 			return
 		}
+
 		if _, err := os.Stat(filepath); errors.Is(err, os.ErrNotExist) {
-			conn.Write([]byte("http/1.1 404 Not Found\r\n\r\n"))
+			send404(conn)
 			return
 		}
-		content := request.Body
-		if err := os.WriteFile(filepath, []byte(content), 0644); err == nil {
-			conn.Write([]byte("http/1.1 404 Not Found\r\n\r\n"))
+
+		headerEnd := bytes.Index(buff, []byte("\r\n\r\n"))
+		headerLength := headerEnd + 4
+		if err := os.WriteFile(filepath, buff[headerLength:n], 0644); err == nil {
+			send404(conn)
 			return
 		}
 		conn.Write([]byte("http/1.1 201 Created \r\n\\r\n"))
 	} else {
-		conn.Write([]byte("http/1.1 404 not found\r\n\r\n"))
+		send404(conn)
 	}
+}
+
+func send404(conn net.Conn) error {
+	body := "404 not found\n"
+	response := "HTTP/1.1 404 Not Found\r\n" +
+		"Content-Type: text/plain\r\n" +
+		"Content-Length: " + strconv.Itoa(len(body)) + "\r\n" +
+		"\r\n" +
+		body
+
+	_, err := conn.Write([]byte(response))
+	fmt.Println("[ERROR]: request did not match any method or route")
+	return err
 }

--- a/app/temp/example.txt
+++ b/app/temp/example.txt
@@ -1,1 +1,1 @@
-hello
+Hello there


### PR DESCRIPTION
## Description

This fixes the issue #1. 

It takes the length of the header and the total number of bytes actually read by the TCP connection and then slices out the `[]byte` with appropriate lower and upper bounds to avoid any garbage value. 

This PR also adds
- Proper HTTP responses for all 404s. Previously they were not following the HTTP specification when the server received `curl` commands from the terminal. 
- Logging for all 404s.
- Formatting in certain long strings.

A better solution would be to read all the headers and maintain a map of them and then use `Content-Length` from there upon the `request.Body` field.